### PR TITLE
Update stefanzweifel/git-auto-commit-action to v5

### DIFF
--- a/scrape.yaml
+++ b/scrape.yaml
@@ -1,0 +1,45 @@
+name: Collect ActBlue ticker value
+
+on:
+  schedule:
+    - cron: "*/15 * * * *" # every 15 minutes
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_hash: ${{ steps.auto-commit-action.outputs.commit_hash }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Run scraper
+        id: scraper
+        run: ./scrape.sh
+
+      - name: Commit sitewide_raised_amount.txt to GitHub
+        id: auto-commit-action
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Changed by ${{ env.difference }}
+          file_pattern: sitewide_raised_amount.txt
+
+  insert:
+    runs-on: ubuntu-latest
+    needs: scrape
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.scrape.outputs.commit_hash }}
+
+      - name: Run inserter
+        id: inserter
+        run: ./insert.sh
+
+      - name: Commit amounts.csv to GitHub
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: main
+          commit_message: amounts.csv updated
+          file_pattern: amounts.csv


### PR DESCRIPTION
Related to #2

Update `stefanzweifel/git-auto-commit-action` to `v5` in the GitHub Actions workflow.

* Update the `stefanzweifel/git-auto-commit-action` version from `v4` to `v5` in the `scrape` job.
* Update the `stefanzweifel/git-auto-commit-action` version from `v4` to `v5` in the `insert` job.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rdmurphy/actblue-ticker-tracker/issues/2?shareId=fec3f426-07a2-4e27-b699-ea4b61bc0f39).